### PR TITLE
Add Flask React chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# hello_world
-I'm just messing around here.
+# Flask React LangGraph Example
+
+This project demonstrates a minimal Flask backend with a React frontend that communicates with a simple LangGraph-like chat agent. The agent exposes a small set of tools (currently only a calculator). The frontend is served directly from Flask and uses React from a CDN.
+
+## Running
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Start the server:
+
+```bash
+python app.py
+```
+
+3. Open `http://localhost:5000` in your browser to chat with the agent. Prefix messages with `tool:calc:` to evaluate a Python expression.
+
+This code is intentionally minimal and uses placeholder logic. You can extend the agent and tools by modifying `app.py`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, request, jsonify, render_template
+
+app = Flask(__name__)
+
+# --- Simple placeholder tools ---
+def calculate(expression: str) -> str:
+    try:
+        return str(eval(expression, {"__builtins__": {}}))
+    except Exception as e:
+        return f"error: {e}"
+
+TOOLS = {
+    "calc": calculate,
+}
+
+# --- Placeholder LangGraph chat agent ---
+
+def run_agent(messages):
+    """Very small example of using tools based on user input."""
+    if not messages:
+        return "Hello!"
+    last = messages[-1].get("content", "")
+    if last.startswith("tool:"):
+        try:
+            _, tool_name, arg = last.split(":", 2)
+            tool = TOOLS.get(tool_name)
+            if tool:
+                return tool(arg)
+        except ValueError:
+            pass
+    return f"Echo: {last}"
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.get_json(force=True)
+    messages = data.get('messages', [])
+    reply = run_agent(messages)
+    return jsonify({'reply': reply})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+langgraph

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Flask React Chat</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function App() {
+    const [messages, setMessages] = React.useState([]);
+    const [input, setInput] = React.useState('');
+    const sendMessage = async () => {
+        const newMessages = messages.concat({role: 'user', content: input});
+        setMessages(newMessages);
+        const response = await fetch('/api/chat', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({messages: newMessages})
+        });
+        const data = await response.json();
+        setMessages(newMessages.concat({role: 'assistant', content: data.reply}));
+        setInput('');
+    };
+    return (
+        <div>
+            <h1>React LangGraph Chat</h1>
+            <div style={{border: '1px solid #ccc', padding: '10px', height: '300px', overflowY: 'scroll'}}>
+                {messages.map((m, i) => <div key={i}><strong>{m.role}:</strong> {m.content}</div>)}
+            </div>
+            <input value={input} onChange={e => setInput(e.target.value)} onKeyDown={e => {if(e.key==='Enter') sendMessage();}} />
+            <button onClick={sendMessage}>Send</button>
+        </div>
+    );
+}
+ReactDOM.render(<App />, document.getElementById('root'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal Flask backend with a toy LangGraph-like agent
- add React-based chat frontend served from Flask
- document how to run the example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68577392a3688323840eb462e22d8056